### PR TITLE
Update use dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "snapdragon-util": "^2.1.1",
     "source-map": "^0.5.6",
     "source-map-resolve": "^0.5.0",
-    "use": "^2.0.2"
+    "use": "^3.1.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
I'm again trying to update micromatch in babel (https://github.com/babel/babel/pull/5992), and this fixes the current problem with it. use v3 removed lazy-require which does not play well with webpack. I tested it locally in babel and with this update webpack is now able to bundle micromatch fine.

Breaking change seems to be the rename of `options.fn` to `options.hook`, but snapdragon isn't even providing options afaics.

Might also fix jonschlinkert/use#11