### PR TITLE
fix(options): Correctly extend and use supplied options

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function Snapdragon(options) {
   }
 
   this.define('cache', {});
-  this.options = extend({source: 'string'}, this.options);
+  this.options = extend({source: 'string'}, options);
   this.isSnapdragon = true;
   this.plugins = {
     fns: [],

--- a/test/snapdragon.options.js
+++ b/test/snapdragon.options.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('mocha');
+var assert = require('assert');
+var Snapdragon = require('..');
+
+describe('.options', function() {
+  it('should correctly accept and store options in constructor', function() {
+    var snap = new Snapdragon({
+      a: true,
+      b: null,
+      c: false,
+      d: 'd'
+    });
+
+    assert.strictEqual(snap.options['a'], true);
+    assert.strictEqual(snap.options['b'], null);
+    assert.strictEqual(snap.options['c'], false);
+    assert.strictEqual(snap.options['d'], 'd');
+  });
+});


### PR DESCRIPTION
Seems this broke in 9addfcbc56405bb774e653f1d706184aa8c45dcd. Supplied options were not correctly added to `this.options`.
I think this is one of the last missing pieces for getting the new snapdragon running in nanomatch.
