### PR TITLE
Update dependencies and fix issue with only opening nodes

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -5,7 +5,6 @@ var util = require('snapdragon-util');
 var Emitter = require('component-emitter');
 var define = require('define-property');
 var extend = require('extend-shallow');
-var debug = require('debug')('snapdragon:compiler');
 var error = require('./error');
 
 /**
@@ -22,7 +21,6 @@ var error = require('./error');
  */
 
 function Compiler(options, state) {
-  debug('initializing', __filename);
   this.options = extend({source: 'string'}, options);
   this.emitter = new Emitter();
   this.on = this.emitter.on.bind(this.emitter);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "component-emitter": "^1.2.1",
-    "debug": "^3.1.0",
     "define-property": "^2.0.2",
     "extend-shallow": "^3.0.2",
     "get-value": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   },
   "dependencies": {
     "component-emitter": "^1.2.1",
-    "debug": "^2.6.2",
-    "define-property": "^0.2.5",
-    "extend-shallow": "^2.0.1",
+    "debug": "^3.1.0",
+    "define-property": "^2.0.2",
+    "extend-shallow": "^3.0.2",
     "get-value": "^2.0.6",
     "isobject": "^3.0.0",
     "map-cache": "^0.2.2",
     "snapdragon-node": "^1.0.6",
-    "snapdragon-util": "^2.1.1",
+    "snapdragon-util": "^4.0.0",
     "source-map": "^0.5.6",
     "source-map-resolve": "^0.5.0",
     "use": "^3.1.0"

--- a/test/compile.js
+++ b/test/compile.js
@@ -10,6 +10,13 @@ var parser;
 describe('compiler', function() {
   beforeEach(function() {
     compiler = new Compile();
+    compiler
+      .set('parens.open', function(node) {
+        return this.emit('(', node);
+      })
+      .set('parens.close', function(node) {
+        return this.emit(')', node);
+      });
     parser = new Parser();
     parser
       .set('text', function() {
@@ -22,6 +29,20 @@ describe('compiler', function() {
       .set('slash', function() {
         var pos = this.position();
         var match = this.match(/^\//);
+        if (match) {
+          return pos(this.node(match[0]))
+        }
+      })
+      .set('parens.open', function() {
+        var pos = this.position();
+        var match = this.match(/^\(/);
+        if (match) {
+          return pos(this.node(match[0]))
+        }
+      })
+      .set('parens.close', function() {
+        var pos = this.position();
+        var match = this.match(/^\)/);
         if (match) {
           return pos(this.node(match[0]))
         }
@@ -57,6 +78,12 @@ describe('compiler', function() {
       var ast = parser.parse('a/b/c');
       var res = compiler.compile(ast);
       assert.equal(res.output, 'a-b-c');
+    });
+
+    it('should compile close without open', function() {
+      var ast = parser.parse('a)');
+      var res = compiler.compile(ast);
+      assert.equal(res.output, 'a)');
     });
   });
 });


### PR DESCRIPTION
I was running in the following issue in `extglob` when updating it to the latest version of `snapdragon`:

```
Error: expected state.inside.parens to be an array
      at Object.exports.removeType (node_modules/snapdragon-util/index.js:572:11)
      at Compiler.visit (lib/compiler.js:206:12)
      at Compiler.mapVisit (lib/compiler.js:231:23)
      at Compiler.compile (lib/compiler.js:263:12)
      at Context.<anonymous> (test/compile.js:85:26)
```

It seems it was already fixed in `snapdragon-util` so I updated it.

I checked all usages of `util` and nothing that snapdragon uses was renamed or had api changes.

All the other updates breaking changes seem to not affect snapdragon.

I also initially tried upgrading `snapdragon-node` but this introduces a lot of breaking changes which not only affect snapdragon, but all related packages (`capture`, `capture-set`, ...) so that is a story on its own.