### PR TITLE
Bump dependencies. Reduce deps size twice.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -73,7 +73,7 @@ Parser.prototype = Emitter({
       errors: this.errors
     }));
 
-    this.ast.pushNode(this.bos);
+    this.ast.push(this.bos);
     this.nodes = [this.ast];
   },
 
@@ -159,10 +159,10 @@ Parser.prototype = Emitter({
 
     return function(node) {
       if (!node.isNode) node = new Node(node);
-      node.define('position', new Position(start, self));
-      node.define('parsed', parsed);
-      node.define('inside', self.stack.length > 0);
-      node.define('rest', self.input);
+      define(node, 'position', new Position(start, self));
+      define(node, 'parsed', parsed);
+      define(node, 'inside', self.stack.length > 0);
+      define(node, 'rest', self.input);
       return node;
     };
   },
@@ -549,7 +549,7 @@ Parser.prototype = Emitter({
       throw new Error('expected node to be an instance of Node');
     }
     if (node.visited) return;
-    node.define('visited', true);
+    define(node, 'visited', true);
     node = fn(node) || node;
     if (node.nodes) {
       this.mapVisit(node.nodes, fn, node);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "map-cache": "^0.2.2",
     "snapdragon-node": "^1.0.6",
     "snapdragon-util": "^4.0.0",
-    "source-map": "^0.5.6",
+    "source-map": "^0.7.0",
     "source-map-resolve": "^0.5.0",
     "use": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "get-value": "^2.0.6",
     "isobject": "^3.0.0",
     "map-cache": "^0.2.2",
-    "snapdragon-node": "^1.0.6",
+    "snapdragon-node": "^3.0.0",
     "snapdragon-util": "^4.0.0",
     "source-map": "^0.7.0",
     "source-map-resolve": "^0.5.0",


### PR DESCRIPTION
This needs tests to be fixed. Any help would be appreciated.

Before:

```
┌────────────────────┬─────────────┬───────┐
│ name               │ children    │ size  │
├────────────────────┼─────────────┼───────┤
│ source-map         │ 0           │ 0.73M │
├────────────────────┼─────────────┼───────┤
│ snapdragon-node    │ 21          │ 0.55M │
├────────────────────┼─────────────┼───────┤
│ source-map-resolve │ 5           │ 0.15M │
├────────────────────┼─────────────┼───────┤
│ define-property    │ 7           │ 0.11M │
├────────────────────┼─────────────┼───────┤
│ snapdragon-util    │ 1           │ 0.07M │
├────────────────────┼─────────────┼───────┤
│ extend-shallow     │ 4           │ 0.04M │
├────────────────────┼─────────────┼───────┤
│ use                │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ component-emitter  │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ isobject           │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ map-cache          │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ get-value          │ 0           │ 0.00M │
├────────────────────┼─────────────┼───────┤
│ 11 modules         │ 16 children │ 1.24M │
└────────────────────┴─────────────┴───────┘
```

After:

```
┌────────────────────┬─────────────┬───────┐
│ name               │ children    │ size  │
├────────────────────┼─────────────┼───────┤
│ source-map         │ 0           │ 0.30M │
├────────────────────┼─────────────┼───────┤
│ source-map-resolve │ 5           │ 0.15M │
├────────────────────┼─────────────┼───────┤
│ define-property    │ 7           │ 0.11M │
├────────────────────┼─────────────┼───────┤
│ snapdragon-util    │ 1           │ 0.07M │
├────────────────────┼─────────────┼───────┤
│ extend-shallow     │ 4           │ 0.04M │
├────────────────────┼─────────────┼───────┤
│ snapdragon-node    │ 0           │ 0.03M │
├────────────────────┼─────────────┼───────┤
│ use                │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ component-emitter  │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ isobject           │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ map-cache          │ 0           │ 0.01M │
├────────────────────┼─────────────┼───────┤
│ get-value          │ 0           │ 0.00M │
├────────────────────┼─────────────┼───────┤
│ 11 modules         │ 12 children │ 0.66M │
└────────────────────┴─────────────┴───────┘
```

Closes #13, #18.