### PR TITLE
Update source-map-resolve to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "snapdragon-node": "^1.0.6",
     "snapdragon-util": "^4.0.0",
     "source-map": "^0.5.6",
-    "source-map-resolve": "^0.5.0",
+    "source-map-resolve": "^0.6.0",
     "use": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR update the `source-map-resolve` module to v0.6.0
Note that `source-map` is different from `source-map-resolve`, so the #13 is not applied here

Closes #24 
